### PR TITLE
Rename xorg packages according to warnings + switch to channel tarball

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,17 +21,14 @@
     "nixpkgs": {
       "locked": {
         "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
+        "narHash": "sha256-wMN1gM00sUQ2KC9CNr/XEOGdfOrl67PabIRv9AYayTo=",
         "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre985613.0726a0ecb6d4/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake for building Binary Ninja";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/package.nix
+++ b/package.nix
@@ -12,7 +12,10 @@
   libGL,
   glib,
   fontconfig,
-  xorg,
+  libxi,
+  libxrender,
+  libxcb-image,
+  libxcb-render-util,
   dbus,
   libxkbcommon,
   wayland,
@@ -56,10 +59,10 @@ stdenv.mkDerivation {
     libGL
     glib
     fontconfig
-    xorg.libXi
-    xorg.libXrender
-    xorg.xcbutilimage
-    xorg.xcbutilrenderutil
+    libxi
+    libxrender
+    libxcb-image
+    libxcb-render-util
     kdePackages.qtbase
     kdePackages.qtdeclarative
     kdePackages.qtwayland


### PR DESCRIPTION
When building my system on `nixos-unstable` I've been getting:
```
evaluation warning: The xorg package set has been deprecated, 'xorg.libXi' has been renamed to 'libxi'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXrender' has been renamed to 'libxrender'
evaluation warning: The xorg package set has been deprecated, 'xorg.xcbutilimage' has been renamed to 'libxcb-image'
evaluation warning: The xorg package set has been deprecated, 'xorg.xcbutilrenderutil' has been renamed to 'libxcb-render-util'
```

I've done the appropriate renaming and also swapped out the `github:` nixpkgs url over to the channel tarball ([see why](https://discourse.nixos.org/t/danish-road-traffic-authority-switches-from-microsoft-to-linux/74117/24?u=peterc-s)).

Passes `nix flake check` and `nix build` for me.